### PR TITLE
Identify 64-bit IDA Pro database

### DIFF
--- a/jvd/ida/ida.py
+++ b/jvd/ida/ida.py
@@ -37,16 +37,8 @@ class IDA(DisassemblerAbstract):
             raise FileNotFoundError('IDA is not found!')
         log = None
         program = ida64
-        extension = None
         if file_type.startswith('IDA '):
-            # 32-bit database
-            program = ida32
-            extension = '.idb'
-        elif file_type.startswith('FoxPro FPT'):
-            # 64-bit database
-            program = ida64
-            extension = '.i64'
-        if extension:
+            program, extension = (ida64, '.i64') if '64' in file_type else (ida32, '.idb')
             db = file + extension
             if not os.path.exists(db):
                 shutil.copyfile(file, db)


### PR DESCRIPTION
JVD relies on 'magic' to detect file types, but the latter only detect 32-bit IDA Pro databases, not the 64-bit version. 

With this small code change and by adding the following to `~/.magic` (or creating it), JVD can properly identify the file format:
```text
# IDA (Interactive Disassembler) 64-bit database
0       string          IDA2    IDA (Interactive Disassembler) 64-bit database
``` 

This file format signature not only benefit JVD, but any other application that uses 'magic' directly or indirectly. 

Note: it was not clear if the above should go in JVD `README.md` or rather in the documentation of any other tool that uses JVD to process such files. No documentation was updated in this pull request. 