### PR TITLE
IDA Pro support bug fixes

### DIFF
--- a/jvd/disassembler.py
+++ b/jvd/disassembler.py
@@ -76,7 +76,7 @@ class DisassemblerAbstract(metaclass=ABCMeta):
             if capa and 'capa' not in res:
                 from jvd.capa.extractor import capa_analyze
                 if 'bytes' in res:
-                    file_or_bytes = base64.decodeBase64(res['bytes'])
+                    file_or_bytes = base64.b64decode(res['bytes'])
                 else:
                     file_or_bytes = file
                     

--- a/jvd/ida/ida.py
+++ b/jvd/ida/ida.py
@@ -70,6 +70,8 @@ class IDA(DisassemblerAbstract):
         with check_output_ctx(cmd, timeout=self.timeout, env=sub_env) as log:
             if not log:
                 log = ''
+            if isinstance(log, bytes):
+                log = log.decode('ascii')
 
         if decompile:
             # assuming that IDA does not support decompilation

--- a/jvd/ida/ida_utils.py
+++ b/jvd/ida/ida_utils.py
@@ -25,6 +25,7 @@ from idaapi import *
 from ida_name import *
 from idc import *
 import idaapi
+import ida_bytes
 import ida_ida
 import json
 from collections import defaultdict
@@ -412,10 +413,11 @@ def get_all(function_eas: list = None, with_blocks=True, current_ea=False, inclu
         'functions_src': []
     }
     if include_bytes:
-        ea_min = ida_ida.inf_get_min_ea()
-        ea_max = ida_ida.inf_get_max_ea()
-        data['bytes'] = base64.b64encode(idaapi.get_bytes(
-           ea_min, ea_max - ea_min
-        )).decode('ascii')  
+        all_bytes = bytearray()
+        chunk_ea = ida_ida.inf_get_min_ea()
+        while chunk_ea != idaapi.BADADDR:
+            all_bytes.extend(idaapi.get_bytes(chunk_ea, ida_bytes.chunk_size(chunk_ea)))
+            chunk_ea = ida_bytes.next_chunk(chunk_ea)
+        data['bytes'] = base64.b64encode(all_bytes).decode('ascii')  
     return data
 


### PR DESCRIPTION
This cover three small issues:

- `base64.decodeBase64()` does not exist, it is `b64decode()`
- IDA Pro logs (at least on Windows version of IDA Pro) are of type `bytes`, not `str`. 
   - Code using such logs expect strings, such as exception handling in `disassembly.py`:`disassemble()`.
   - Note: maybe 'ascii' isn't the most appropriate encoding, it's hard to tell in this case. 
- `include_bytes`: Actual bytes from the original binary can be distributed in sparse segments in the address space, and "no man's land" bytes should not be returned. 
  - For instance, an `idb` with bytes in [0x00010000, 0x0001f000] and [0xf4000000, 0xf4001000] should only have those bytes returned. Taking all bytes within `[min_ea, max_ea[` returns nearly 4 GB of base64-encoded bytes, while only 1 MB actually exist. This could be catastrophic on 64-bit databases.  
