### PR TITLE
Fix: extract correct mnemonic on IDA Pro

### DIFF
--- a/jvd/ida/ida_utils.py
+++ b/jvd/ida/ida_utils.py
@@ -352,7 +352,6 @@ def get_all(function_eas: list = None, with_blocks=True, current_ea=False, inclu
                     mne = print_insn_mnem(head)
                     if mne == "":
                         continue
-                    mne = GetDisasm(head).split()[0]
                     mne = mne.upper()
                     oprs = []
                     oprs_tp = []


### PR DESCRIPTION
# Issue

IDA `GetDisasm()` may not be an unambiguous way to extract an instruction mnemonic. 

## No-operand Mnemonic

`GetDisasm()` concatenates the comment with the disassembly. On no-operand mnemonics, the comment is concatenated without any separator, whether it's an automatic or manual comment. For instance:

- Intel
  - `retn                    ; I'm out!`
  - `GetDisasm()` returns `"retn; I'm out!"`
- ARM
  - `se_blr                  # Branch unconditionally`
  - `GetDisasm()` returns `"se_blr# Branch unconditionally"`

In `jvd/ida/ida_utils.py`, extracting the mnemonic with `GetDisasm(head).split()[0]` produce an extra character in those cases, i.e. `retn;` and `se_blr#` respectively, which is incorrect.

## Intel Prefixes

Intel prefixes such as `rep` and `lock` in `rep stosd` and `lock xadd op1, op2` for instance, are also returned by `GetDisasm()`. `jvd` thus extract the first word, the prefix, rather than the mnemonic.

Other processors might have such prefix as well. 


# Proposed Fix

Keep the mnemonic from `print_insn_mnem(head)` collected three lines above.

In the above example, `retn` and `se_blr` are properly returned. 

In prefix cases, the fix returns the actual mnemonic only, without the prefix. It seems more semantically correct to return the mnemonic alone than the prefix alone as with original code. It is not clear though whether the prefix should be returned as part of 

a) mnemonic
b) operands
c) something else
d) none of the above

The proposed fix goes for d) since it is not returned at all. 
  